### PR TITLE
Context used for torrentfs, torrent tracking

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -213,7 +213,7 @@ func (fs *TorrentFS) Download(ctx context.Context, ih string, request int64) err
 		return err
 	} else {
 		if update {
-			if err := fs.storage().Search(ctx, ih, request, false); err != nil {
+			if err := fs.storage().Search(ctx, ih, request); err != nil {
 				return err
 			}
 		}

--- a/fs.go
+++ b/fs.go
@@ -213,7 +213,7 @@ func (fs *TorrentFS) Download(ctx context.Context, ih string, request int64) err
 		return err
 	} else {
 		if update {
-			if err := fs.storage().Search(ih, request, false); err != nil {
+			if err := fs.storage().Search(ctx, ih, request, false); err != nil {
 				return err
 			}
 		}

--- a/handler.go
+++ b/handler.go
@@ -50,10 +50,10 @@ import (
 )
 
 const (
-	bucket                  = params.Bucket //it is best size is 1/3 full nodes
-	group                   = params.Group
-	updateTorrentChanBuffer = params.SyncBatch
-	torrentChanSize         = 64
+	bucket = params.Bucket //it is best size is 1/3 full nodes
+	group  = params.Group
+	//updateTorrentChanBuffer = params.SyncBatch
+	torrentChanSize = 64
 
 	torrentPending = iota //2
 	torrentPaused
@@ -385,7 +385,7 @@ func NewTorrentManager(config *Config, fsid uint64, cache, compress bool) (*Torr
 		TmpDataDir:          tmpFilePath,
 		boostFetcher:        NewBoostDataFetcher(config.BoostNodes),
 		closeAll:            make(chan struct{}),
-		updateTorrent:       make(chan interface{}, updateTorrentChanBuffer),
+		updateTorrent:       make(chan interface{}), // updateTorrentChanBuffer),
 		seedingChan:         make(chan *Torrent, torrentChanSize),
 		activeChan:          make(chan *Torrent, torrentChanSize),
 		pendingChan:         make(chan *Torrent, torrentChanSize),
@@ -430,7 +430,6 @@ func NewTorrentManager(config *Config, fsid uint64, cache, compress bool) (*Torr
 }
 
 func (tm *TorrentManager) Start() error {
-	tm.init()
 
 	tm.wg.Add(1)
 	go tm.mainLoop()
@@ -441,6 +440,8 @@ func (tm *TorrentManager) Start() error {
 	go tm.activeLoop()
 	tm.wg.Add(1)
 	go tm.seedingLoop()
+
+	tm.init()
 
 	return nil
 }

--- a/handler.go
+++ b/handler.go
@@ -535,22 +535,25 @@ func (tm *TorrentManager) mainLoop() {
 			}
 
 			if meta.IsCreate {
-				counter := 0
-				for {
-					if t := tm.addInfoHash(meta.InfoHash, int64(meta.BytesRequested)); t != nil {
-						log.Debug("Seed [create] success", "ih", meta.InfoHash, "request", meta.BytesRequested)
-						if int64(meta.BytesRequested) > 0 {
-							tm.updateInfoHash(meta.InfoHash, int64(meta.BytesRequested))
-						}
-						break
-					} else {
-						if counter > 10 {
-							panic("Fail adding file for 10 times")
-						}
-						log.Error("Seed [create] failed", "ih", meta.InfoHash, "request", meta.BytesRequested, "counter", counter)
-						counter++
+				//counter := 0
+				//for {
+				if t := tm.addInfoHash(meta.InfoHash, int64(meta.BytesRequested)); t != nil {
+					log.Debug("Seed [create] success", "ih", meta.InfoHash, "request", meta.BytesRequested)
+					if int64(meta.BytesRequested) > 0 {
+						tm.updateInfoHash(meta.InfoHash, int64(meta.BytesRequested))
 					}
+				} else {
+					log.Error("Seed [create] failed", "ih", meta.InfoHash, "request", meta.BytesRequested)
 				}
+				//		break
+				//	} else {
+				//		if counter > 10 {
+				//			panic("Fail adding file for 10 times")
+				//		}
+				//		log.Error("Seed [create] failed", "ih", meta.InfoHash, "request", meta.BytesRequested, "counter", counter)
+				//		counter++
+				//	}
+				//}
 			} else {
 				log.Debug("Seed [update] success", "ih", meta.InfoHash, "request", meta.BytesRequested)
 				tm.updateInfoHash(meta.InfoHash, int64(meta.BytesRequested))

--- a/handler_test.go
+++ b/handler_test.go
@@ -15,7 +15,7 @@ func TestGetFile(t *testing.T) {
 	fmt.Println(DefaultConfig)
 	tm, _ := NewTorrentManager(&DefaultConfig, 1, false, false)
 	tm.Start()
-	tm.Search(context.Background(), ih, 0, false)
+	tm.Search(context.Background(), ih, 0)
 	defer tm.Close()
 	time.Sleep(3 * time.Second)
 	a, _ := tm.Available(ih, 100000000)

--- a/handler_test.go
+++ b/handler_test.go
@@ -14,8 +14,8 @@ func TestGetFile(t *testing.T) {
 	ih := "aea5584d0cd3865e90c80eace3bfcb062473d966"
 	fmt.Println(DefaultConfig)
 	tm, _ := NewTorrentManager(&DefaultConfig, 1, false, false)
-	tm.Search(context.Background(), ih, 0, false)
 	tm.Start()
+	tm.Search(context.Background(), ih, 0, false)
 	defer tm.Close()
 	time.Sleep(3 * time.Second)
 	a, _ := tm.Available(ih, 100000000)

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,6 +1,7 @@
 package torrentfs
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"testing"
@@ -13,7 +14,7 @@ func TestGetFile(t *testing.T) {
 	ih := "aea5584d0cd3865e90c80eace3bfcb062473d966"
 	fmt.Println(DefaultConfig)
 	tm, _ := NewTorrentManager(&DefaultConfig, 1, false, false)
-	tm.Search(ih, 0, false)
+	tm.Search(context.Background(), ih, 0, false)
 	tm.Start()
 	defer tm.Close()
 	time.Sleep(3 * time.Second)

--- a/sync.go
+++ b/sync.go
@@ -122,7 +122,7 @@ func NewMonitor(flag *Config, cache, compress, listen bool) (*Monitor, error) {
 
 	torrents, _ := fs.initTorrents()
 	for k, v := range torrents {
-		if err := tMana.Search(context.Background(), k, int64(v), true); err != nil {
+		if err := tMana.Search(context.Background(), k, int64(v)); err != nil {
 			return nil, err
 		}
 	}
@@ -189,7 +189,6 @@ func (m *Monitor) indexInit() error {
 		m.dl.UpdateTorrent(context.Background(), types.FlowControlMeta{
 			InfoHash:       file.Meta.InfoHash,
 			BytesRequested: bytesRequested,
-			IsCreate:       true,
 		})
 		if file.LeftSize == 0 {
 			seed++
@@ -356,7 +355,6 @@ func (m *Monitor) parseFileMeta(tx *types.Transaction, meta *types.FileMeta, b *
 		m.dl.UpdateTorrent(context.Background(), types.FlowControlMeta{
 			InfoHash:       meta.InfoHash,
 			BytesRequested: 0,
-			IsCreate:       true,
 		})
 	}
 	return nil
@@ -418,7 +416,6 @@ func (m *Monitor) parseBlockTorrentInfo(b *types.Block) (bool, error) {
 						m.dl.UpdateTorrent(context.Background(), types.FlowControlMeta{
 							InfoHash:       file.Meta.InfoHash,
 							BytesRequested: bytesRequested,
-							IsCreate:       false,
 						})
 					}
 				}

--- a/sync.go
+++ b/sync.go
@@ -17,6 +17,7 @@ package torrentfs
 // along with the CortexTheseus library. If not, see <http://www.gnu.org/licenses/>.
 
 import (
+	"context"
 	"errors"
 	"github.com/CortexFoundation/CortexTheseus/common"
 	"github.com/CortexFoundation/CortexTheseus/common/hexutil"
@@ -121,7 +122,9 @@ func NewMonitor(flag *Config, cache, compress, listen bool) (*Monitor, error) {
 
 	torrents, _ := fs.initTorrents()
 	for k, v := range torrents {
-		tMana.Search(k, int64(v), true)
+		if err := tMana.Search(context.Background(), k, int64(v), true); err != nil {
+			return nil, err
+		}
 	}
 
 	m.indexInit()
@@ -183,7 +186,7 @@ func (m *Monitor) indexInit() error {
 		}
 		capcity += bytesRequested
 		log.Debug("File storage info", "addr", file.ContractAddr, "ih", file.Meta.InfoHash, "remain", common.StorageSize(file.LeftSize), "raw", common.StorageSize(file.Meta.RawSize), "request", common.StorageSize(bytesRequested))
-		m.dl.UpdateTorrent(types.FlowControlMeta{
+		m.dl.UpdateTorrent(context.Background(), types.FlowControlMeta{
 			InfoHash:       file.Meta.InfoHash,
 			BytesRequested: bytesRequested,
 			IsCreate:       true,
@@ -350,7 +353,7 @@ func (m *Monitor) parseFileMeta(tx *types.Transaction, meta *types.FileMeta, b *
 	}
 	if update && op == 1 {
 		log.Debug("Create new file", "ih", meta.InfoHash, "op", op)
-		m.dl.UpdateTorrent(types.FlowControlMeta{
+		m.dl.UpdateTorrent(context.Background(), types.FlowControlMeta{
 			InfoHash:       meta.InfoHash,
 			BytesRequested: 0,
 			IsCreate:       true,
@@ -412,7 +415,7 @@ func (m *Monitor) parseBlockTorrentInfo(b *types.Block) (bool, error) {
 							log.Debug("Data processing ...", "ih", file.Meta.InfoHash, "addr", (*tx.Recipient).String(), "remain", common.StorageSize(remainingSize), "request", common.StorageSize(bytesRequested), "raw", common.StorageSize(file.Meta.RawSize), "number", b.Number)
 						}
 
-						m.dl.UpdateTorrent(types.FlowControlMeta{
+						m.dl.UpdateTorrent(context.Background(), types.FlowControlMeta{
 							InfoHash:       file.Meta.InfoHash,
 							BytesRequested: bytesRequested,
 							IsCreate:       false,

--- a/types/common.go
+++ b/types/common.go
@@ -170,5 +170,5 @@ type FileMeta struct {
 type FlowControlMeta struct {
 	InfoHash       metainfo.Hash
 	BytesRequested uint64
-	IsCreate       bool
+	//IsCreate       bool
 }


### PR DESCRIPTION
It is useful to track the torrent status after register. So context is a good point here.
We can retry or others to make torrent routine running correctly.