### PR TITLE
Nas 2.0 with new downloading mode

### DIFF
--- a/chaindb.go
+++ b/chaindb.go
@@ -748,12 +748,12 @@ func (fs *ChainDB) SetTorrent(ih string, size uint64) (bool, uint64, error) {
 }
 
 // GetTorrent return the torrent status by uint64, if return 0 for torrent not exist
-func (fs *ChainDB) GetTorrent(ih string) (status bool, progress uint64, err error) {
+func (fs *ChainDB) GetTorrent(ih string) (progress uint64, err error) {
 	fs.lock.RLock()
 	defer fs.lock.RUnlock()
 
 	if s, ok := fs.torrents[ih]; ok {
-		return true, s, nil
+		return s, nil
 	}
 	cb := func(tx *bolt.Tx) error {
 		buk := tx.Bucket([]byte("torrent_" + fs.version))
@@ -777,12 +777,12 @@ func (fs *ChainDB) GetTorrent(ih string) (status bool, progress uint64, err erro
 		return nil
 	}
 	if err := fs.db.View(cb); err != nil {
-		return false, 0, err
+		return 0, err
 	}
 
 	fs.torrents[ih] = progress
 
-	return true, progress, nil
+	return progress, nil
 }
 
 func (fs *ChainDB) initTorrents() (map[string]uint64, error) {

--- a/doc.go
+++ b/doc.go
@@ -33,6 +33,6 @@ const (
 
 	peerStateCycle    = time.Second * 60
 	expirationCycle   = time.Second
-	transmissionCycle = 5 * time.Second
+	transmissionCycle = 1 * time.Second
 	handshakeTimeout  = 60 * time.Second
 )

--- a/doc.go
+++ b/doc.go
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with the CortexTheseus library. If not, see <http://www.gnu.org/licenses/>.
+
 package torrentfs
 
 import (
@@ -21,9 +22,9 @@ import (
 
 const (
 	ProtocolName         = "nas"
-	ProtocolVersion      = uint64(1)
+	ProtocolVersion      = uint64(2)
 	NumberOfMessageCodes = 128
-	ProtocolVersionStr   = "1.0"
+	ProtocolVersionStr   = "2.0"
 
 	DefaultMaxMessageSize = uint32(1024)
 

--- a/doc.go
+++ b/doc.go
@@ -28,8 +28,9 @@ const (
 
 	DefaultMaxMessageSize = uint32(1024)
 
-	statusCode   = 0
-	messagesCode = 1
+	statusCode = 0
+	queryCode  = 1
+	msgCode    = 2
 
 	peerStateCycle    = time.Second * 60
 	expirationCycle   = time.Second

--- a/fs.go
+++ b/fs.go
@@ -259,7 +259,7 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 					t := float64(cost) / (1000 * 1000 * 1000)
 					speed = float64(f) / t
 				}
-				invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0)
+				invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0) || (time.Duration(cost) > time.Second*15 && f == 0 && cost == 0)
 				if ProtocolVersion == 2 && f < rawSize && invoke && speed < 256*1024 {
 					go func() {
 						log.Error("Nas 2.0 query", "ih", infohash, "queue", len(fs.queryChan), "raw", rawSize, "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)

--- a/fs.go
+++ b/fs.go
@@ -182,9 +182,11 @@ func (tfs *TorrentFS) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 				}
 				if _, suc := tfs.nasCache.Get(info.Hash); !suc {
 					log.Error("Nas msg received", "version", ProtocolVersion, "msg", info)
-					if err := tfs.storage().Search(context.Background(), info.Hash, info.Size, nil); err != nil {
-						log.Error("Nas 2.0 error", "err", err)
-						return err
+					if progress, e := tfs.chain().GetTorrent(info.Hash); e == nil && progress >= info.Size {
+						if err := tfs.storage().Search(context.Background(), info.Hash, info.Size, nil); err != nil {
+							log.Error("Nas 2.0 error", "err", err)
+							return err
+						}
 					}
 					tfs.nasCache.Add(info.Hash, info.Size)
 				}

--- a/fs.go
+++ b/fs.go
@@ -262,7 +262,7 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 				invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0) || (time.Duration(cost) > time.Second*15 && f == 0 && cost == 0)
 				if ProtocolVersion == 2 && f < rawSize && invoke && speed < 256*1024 {
 					go func() {
-						log.Error("Nas 2.0 query", "ih", infohash, "queue", len(fs.queryChan), "raw", rawSize, "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
+						log.Error("Nas 2.0 query", "ih", infohash, "queue", len(fs.queryChan), "raw", common.StorageSize(float64(rawSize)), "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
 						fs.queryChan <- Query{Hash: infohash, Size: rawSize}
 					}()
 					fs.nasCache.Add(infohash, rawSize)

--- a/fs.go
+++ b/fs.go
@@ -234,6 +234,10 @@ func (tfs *TorrentFS) Stop() error {
 	}
 	// Wait until every goroutine terminates.
 	tfs.monitor.stop()
+
+	if tfs.nasCache != nil {
+		tfs.nasCache.Purge()
+	}
 	return nil
 }
 
@@ -258,7 +262,7 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 				invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0)
 				if ProtocolVersion == 2 && f < rawSize && invoke && speed < 256*1024 {
 					go func() {
-						log.Error("Nas 2.0 query", "ih", infohash, "cap", cap(fs.queryChan), "len", len(fs.queryChan), "available", ret, "raw", rawSize, "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "err", err)
+						log.Error("Nas 2.0 query", "ih", infohash, "cap", cap(fs.queryChan), "len", len(fs.queryChan), "available", ret, "raw", rawSize, "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
 						fs.queryChan <- Query{Hash: infohash, Size: rawSize}
 					}()
 					fs.nasCache.Add(infohash, rawSize)

--- a/fs.go
+++ b/fs.go
@@ -39,7 +39,7 @@ type TorrentFS struct {
 	peerMu sync.RWMutex     // Mutex to sync the active peer set
 	peers  map[string]*Peer // Set of currently active peers
 
-	queryChan chan Query
+	//queryChan chan Query
 
 	nasCache *lru.Cache
 }
@@ -71,13 +71,13 @@ func New(config *Config, cache, compress, listen bool) (*TorrentFS, error) {
 	}
 
 	inst = &TorrentFS{
-		config:    config,
-		monitor:   monitor,
-		peers:     make(map[string]*Peer),
-		queryChan: make(chan Query, 128),
+		config:  config,
+		monitor: monitor,
+		peers:   make(map[string]*Peer),
+		//queryChan: make(chan Query, 128),
 	}
 
-	inst.nasCache, _ = lru.New(25)
+	inst.nasCache, _ = lru.New(8)
 
 	inst.protocol = p2p.Protocol{
 		Name:    ProtocolName,
@@ -179,7 +179,7 @@ func (tfs *TorrentFS) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 					return errors.New("invalid msg")
 				}
 				if _, suc := tfs.nasCache.Get(info.Hash); !suc {
-					log.Error("Nas msg received", "msg", info)
+					log.Error("Nas msg received", "ih", info.Hash, "size", common.StorageSize(float64(info.Size)))
 					if progress, e := tfs.chain().GetTorrent(info.Hash); e == nil && progress >= info.Size {
 						if err := tfs.storage().Search(context.Background(), info.Hash, info.Size, nil); err != nil {
 							log.Error("Nas 2.0 error", "err", err)
@@ -252,20 +252,20 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 			}
 		}
 	} else if errors.Is(err, ErrUnfinished) {
-		//if _, suc := fs.nasCache.Get(infohash); !suc {
-		var speed float64
-		if cost > 0 {
-			t := float64(cost) / (1000 * 1000 * 1000)
-			speed = float64(f) / t
-		}
-		invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0) || (time.Duration(cost) > time.Second*15 && f == 0 && cost == 0)
-		if ProtocolVersion == 2 && f < rawSize && invoke && speed < 256*1024 {
-			go func() {
-				log.Error("Nas 2.0 query", "ih", infohash, "queue", len(fs.queryChan), "raw", common.StorageSize(float64(rawSize)), "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
-				fs.queryChan <- Query{Hash: infohash, Size: rawSize}
-			}()
-			fs.nasCache.Add(infohash, rawSize)
-			//	}
+		if _, suc := fs.nasCache.Get(infohash); !suc {
+			var speed float64
+			if cost > 0 {
+				t := float64(cost) / (1000 * 1000 * 1000)
+				speed = float64(f) / t
+			}
+			invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0) || (time.Duration(cost) > time.Second*15 && f == 0 && cost == 0)
+			if ProtocolVersion == 2 && f < rawSize && invoke && speed < 256*1024 {
+				//go func() {
+				//	log.Error("Nas 2.0 query", "ih", infohash, "raw", common.StorageSize(float64(rawSize)), "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
+				//fs.queryChan <- Query{Hash: infohash, Size: rawSize}
+				//}()
+				fs.nasCache.Add(infohash, rawSize)
+			}
 		}
 		log.Debug("Torrent sync downloading", "ih", infohash, "available", ret, "raw", rawSize, "finish", f, "err", err)
 	}

--- a/fs.go
+++ b/fs.go
@@ -255,7 +255,7 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 					t := float64(cost) / (1000 * 1000 * 1000)
 					speed = float64(f) / t
 				}
-				if ProtocolVersion == 2 && f < rawSize && time.Duration(cost) > time.Second*60 && speed < 256*1024 {
+				if ProtocolVersion == 2 && f < rawSize && time.Duration(cost) > time.Second*1 && speed < 256*1024 {
 					go func() {
 						log.Error("Nas 2.0 query", "ih", infohash, "cap", cap(fs.queryChan), "len", len(fs.queryChan), "available", ret, "raw", rawSize, "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "err", err)
 						fs.queryChan <- Query{Hash: infohash, Size: rawSize}

--- a/fs.go
+++ b/fs.go
@@ -181,7 +181,7 @@ func (tfs *TorrentFS) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 					return errors.New("invalid msg")
 				}
 				if _, suc := tfs.nasCache.Get(info.Hash); !suc {
-					log.Error("Nas msg received", "version", ProtocolVersion, "msg", info)
+					log.Error("Nas msg received", "msg", info)
 					if progress, e := tfs.chain().GetTorrent(info.Hash); e == nil && progress >= info.Size {
 						if err := tfs.storage().Search(context.Background(), info.Hash, info.Size, nil); err != nil {
 							log.Error("Nas 2.0 error", "err", err)
@@ -255,7 +255,7 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 					t := float64(cost) / (1000 * 1000 * 1000)
 					speed = float64(f) / t
 				}
-				if ProtocolVersion == 2 && f < rawSize && time.Duration(cost) > time.Second*1 && speed < 256*1024 {
+				if ProtocolVersion == 2 && f < rawSize && time.Duration(cost) > time.Second*60 && speed < 256*1024 {
 					go func() {
 						log.Error("Nas 2.0 query", "ih", infohash, "cap", cap(fs.queryChan), "len", len(fs.queryChan), "available", ret, "raw", rawSize, "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "err", err)
 						fs.queryChan <- Query{Hash: infohash, Size: rawSize}

--- a/fs.go
+++ b/fs.go
@@ -255,7 +255,8 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 					t := float64(cost) / (1000 * 1000 * 1000)
 					speed = float64(f) / t
 				}
-				if ProtocolVersion == 2 && f < rawSize && time.Duration(cost) > time.Second*60 && speed < 256*1024 {
+				invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0)
+				if ProtocolVersion == 2 && f < rawSize && invoke && speed < 256*1024 {
 					go func() {
 						log.Error("Nas 2.0 query", "ih", infohash, "cap", cap(fs.queryChan), "len", len(fs.queryChan), "available", ret, "raw", rawSize, "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "err", err)
 						fs.queryChan <- Query{Hash: infohash, Size: rawSize}

--- a/fs.go
+++ b/fs.go
@@ -244,33 +244,33 @@ func (tfs *TorrentFS) Stop() error {
 // Available is used to check the file status
 func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uint64) (bool, error) {
 	ret, f, cost, err := fs.storage().available(infohash, rawSize)
-	if fs.config.Mode == LAZY {
-		if errors.Is(err, ErrInactiveTorrent) {
-			if progress, e := fs.chain().GetTorrent(infohash); e == nil {
-				log.Debug("Lazy mode starting", "ih", infohash, "request", progress)
-				if e := fs.storage().Search(ctx, infohash, progress, nil); e == nil {
-					log.Warn("Torrent wake up", "ih", infohash, "progress", progress, "err", err, "available", ret, "raw", rawSize, "err", err)
-				}
+	//if fs.config.Mode == LAZY {
+	if errors.Is(err, ErrInactiveTorrent) {
+		if progress, e := fs.chain().GetTorrent(infohash); e == nil {
+			log.Debug("Lazy mode starting", "ih", infohash, "request", progress)
+			if e := fs.storage().Search(ctx, infohash, progress, nil); e == nil {
+				log.Warn("Torrent wake up", "ih", infohash, "progress", progress, "err", err, "available", ret, "raw", rawSize, "err", err)
 			}
-		} else if errors.Is(err, ErrUnfinished) {
-			if _, suc := fs.nasCache.Get(infohash); !suc {
-				var speed float64
-				if cost > 0 {
-					t := float64(cost) / (1000 * 1000 * 1000)
-					speed = float64(f) / t
-				}
-				invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0) || (time.Duration(cost) > time.Second*15 && f == 0 && cost == 0)
-				if ProtocolVersion == 2 && f < rawSize && invoke && speed < 256*1024 {
-					go func() {
-						log.Error("Nas 2.0 query", "ih", infohash, "queue", len(fs.queryChan), "raw", common.StorageSize(float64(rawSize)), "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
-						fs.queryChan <- Query{Hash: infohash, Size: rawSize}
-					}()
-					fs.nasCache.Add(infohash, rawSize)
-				}
-			}
-			log.Debug("Torrent sync downloading", "ih", infohash, "available", ret, "raw", rawSize, "finish", f, "err", err)
 		}
+	} else if errors.Is(err, ErrUnfinished) {
+		if _, suc := fs.nasCache.Get(infohash); !suc {
+			var speed float64
+			if cost > 0 {
+				t := float64(cost) / (1000 * 1000 * 1000)
+				speed = float64(f) / t
+			}
+			invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0) || (time.Duration(cost) > time.Second*15 && f == 0 && cost == 0)
+			if ProtocolVersion == 2 && f < rawSize && invoke && speed < 256*1024 {
+				go func() {
+					log.Error("Nas 2.0 query", "ih", infohash, "queue", len(fs.queryChan), "raw", common.StorageSize(float64(rawSize)), "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
+					fs.queryChan <- Query{Hash: infohash, Size: rawSize}
+				}()
+				fs.nasCache.Add(infohash, rawSize)
+			}
+		}
+		log.Debug("Torrent sync downloading", "ih", infohash, "available", ret, "raw", rawSize, "finish", f, "err", err)
 	}
+	//}
 	return ret, err
 }
 

--- a/fs.go
+++ b/fs.go
@@ -262,7 +262,7 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 				invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0)
 				if ProtocolVersion == 2 && f < rawSize && invoke && speed < 256*1024 {
 					go func() {
-						log.Error("Nas 2.0 query", "ih", infohash, "cap", cap(fs.queryChan), "len", len(fs.queryChan), "available", ret, "raw", rawSize, "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
+						log.Error("Nas 2.0 query", "ih", infohash, "queue", len(fs.queryChan), "raw", rawSize, "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
 						fs.queryChan <- Query{Hash: infohash, Size: rawSize}
 					}()
 					fs.nasCache.Add(infohash, rawSize)
@@ -276,6 +276,11 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 
 // GetFile is used to get file from storage, current this will not be call after available passed
 func (fs *TorrentFS) GetFile(ctx context.Context, infohash, subpath string) ([]byte, error) {
+	//func (fs *TorrentFS) GetFile(ctx context.Context, infohash string, rawSize uint64,  subpath string) ([]byte, error) {
+	//if available, err := fs.Available(ctx, infohash, rawSize); err != nil || !available{
+	//	return nil, err
+	//}
+
 	ret, f, err := fs.storage().getFile(infohash, subpath)
 
 	if err != nil {

--- a/fs.go
+++ b/fs.go
@@ -235,7 +235,7 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 				}
 			}
 		} else if errors.Is(err, ErrUnfinished) {
-			if ProtocolVersion == 2 && f == 0{
+			if ProtocolVersion == 2 && f == 0 {
 				go func() {
 					log.Warn("Nas 2.0 query send when checking", "cap", cap(fs.queryChan), "len", len(fs.queryChan), "version", ProtocolVersion)
 					fs.queryChan <- Query{Hash: infohash, Size: rawSize}

--- a/fs.go
+++ b/fs.go
@@ -181,7 +181,7 @@ func (tfs *TorrentFS) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 					return errors.New("invalid msg")
 				}
 				if suc := tfs.queryCache.Contains(info.Hash); !suc {
-					log.Error("Nas msg received", "ih", info.Hash, "size", common.StorageSize(float64(info.Size)))
+					log.Info("Nas msg received", "ih", info.Hash, "size", common.StorageSize(float64(info.Size)))
 					if progress, e := tfs.chain().GetTorrent(info.Hash); e == nil && progress >= info.Size {
 						if err := tfs.storage().Search(context.Background(), info.Hash, info.Size, nil); err != nil {
 							log.Error("Nas 2.0 error", "err", err)
@@ -267,7 +267,7 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 			invoke := time.Duration(cost) > time.Second*60 || (time.Duration(cost) > time.Second*30 && f == 0) || (time.Duration(cost) > time.Second*15 && f == 0 && cost == 0)
 			if ProtocolVersion == 2 && f < rawSize && invoke && speed < 256*1024 {
 				//go func() {
-				log.Error("Nas 2.0 query", "ih", infohash, "raw", common.StorageSize(float64(rawSize)), "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
+				log.Info("Nas 2.0 query", "ih", infohash, "raw", common.StorageSize(float64(rawSize)), "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
 				//fs.queryChan <- Query{Hash: infohash, Size: rawSize}
 				//}()
 				fs.nasCache.Add(infohash, rawSize)

--- a/fs.go
+++ b/fs.go
@@ -264,7 +264,7 @@ func (fs *TorrentFS) Available(ctx context.Context, infohash string, rawSize uin
 				log.Error("Nas 2.0 query", "ih", infohash, "queue", len(fs.queryChan), "raw", common.StorageSize(float64(rawSize)), "finish", f, "cost", common.PrettyDuration(cost), "speed", common.StorageSize(speed), "cache", fs.nasCache.Len(), "err", err)
 				fs.queryChan <- Query{Hash: infohash, Size: rawSize}
 			}()
-			//		fs.nasCache.Add(infohash, rawSize)
+			fs.nasCache.Add(infohash, rawSize)
 			//	}
 		}
 		log.Debug("Torrent sync downloading", "ih", infohash, "available", ret, "raw", rawSize, "finish", f, "err", err)

--- a/handler.go
+++ b/handler.go
@@ -178,6 +178,7 @@ func (tm *TorrentManager) dropAll() {
 }
 
 func (tm *TorrentManager) commit(ctx context.Context, hex string, request uint64, ch chan bool) error {
+	log.Debug("Commit task", "ih", hex, "request", request, "ch", ch)
 	select {
 	case tm.taskChan <- types.FlowControlMeta{
 		InfoHash:       metainfo.NewHashFromHex(hex),
@@ -252,7 +253,8 @@ func (tm *TorrentManager) verifyTorrent(info *metainfo.Info, root string) error 
 	return nil
 }
 
-func (tm *TorrentManager) loadSpec(ih metainfo.Hash, filePath string, BytesRequested int64) *torrent.TorrentSpec {
+//func (tm *TorrentManager) loadSpec(ih metainfo.Hash, filePath string, BytesRequested int64) *torrent.TorrentSpec {
+func (tm *TorrentManager) loadSpec(ih metainfo.Hash, filePath string) *torrent.TorrentSpec {
 	if _, err := os.Stat(filePath); err != nil {
 		return nil
 	}
@@ -312,17 +314,17 @@ func (tm *TorrentManager) addInfoHash(ih metainfo.Hash, BytesRequested int64, ch
 	var spec *torrent.TorrentSpec
 
 	if _, err := os.Stat(seedTorrentPath); err == nil {
-		spec = tm.loadSpec(ih, seedTorrentPath, BytesRequested)
+		spec = tm.loadSpec(ih, seedTorrentPath)
 	} else if _, err := os.Stat(tmpTorrentPath); err == nil {
-		spec = tm.loadSpec(ih, tmpTorrentPath, BytesRequested)
+		spec = tm.loadSpec(ih, tmpTorrentPath)
 	}
 
 	if spec == nil {
 		tmpDataPath := filepath.Join(tm.TmpDataDir, ih.HexString())
 		spec = &torrent.TorrentSpec{
-			//		Trackers: [][]string{}, //tm.trackers, //[][]string{},
 			InfoHash: ih,
 			Storage:  storage.NewFile(tmpDataPath),
+			//Storage: storage.NewFileWithCompletion(tmpDataPath, storage.NewMapPieceCompletion()),
 		}
 	}
 
@@ -385,7 +387,7 @@ func NewTorrentManager(config *Config, fsid uint64, cache, compress bool) (*Torr
 	tmpFilePath := filepath.Join(config.DataDir, defaultTmpPath)
 
 	if _, err := os.Stat(tmpFilePath); err != nil {
-		err = os.MkdirAll(filepath.Dir(tmpFilePath), 0750) //os.FileMode(os.ModePerm))
+		err = os.MkdirAll(filepath.Dir(tmpFilePath), 0770) //os.FileMode(os.ModePerm))
 		if err != nil {
 			log.Error("Mkdir failed", "path", tmpFilePath)
 			return nil, err
@@ -437,7 +439,9 @@ func NewTorrentManager(config *Config, fsid uint64, cache, compress bool) (*Torr
 
 	torrentManager.metrics = config.Metrics
 
-	torrentManager.hotCache, _ = lru.New(32)
+	hotSize := config.MaxSeedingNum/64 + 1
+	torrentManager.hotCache, _ = lru.New(hotSize)
+	log.Info("Hot cache created", "size", hotSize)
 
 	if len(config.DefaultTrackers) > 0 {
 		log.Debug("Tracker list", "trackers", config.DefaultTrackers)
@@ -459,7 +463,6 @@ func (tm *TorrentManager) Start() error {
 
 	tm.wg.Add(1)
 	go tm.mainLoop()
-
 	if tm.mode != LAZY {
 		tm.init()
 	}
@@ -472,7 +475,10 @@ func (tm *TorrentManager) seedingLoop() {
 	for {
 		select {
 		case t := <-tm.seedingChan:
+			tm.lock.Lock()
 			tm.seedingTorrents[t.Torrent.InfoHash()] = t
+			tm.lock.Unlock()
+
 			s := t.Seed()
 			if t.ch != nil {
 				log.Warn("Torrent seeding ready for lazy", "ih", t.InfoHash())
@@ -487,7 +493,7 @@ func (tm *TorrentManager) seedingLoop() {
 				//		go tm.getFile(t.InfoHash(), file.Path())
 				//	}
 				//}
-
+				tm.hotCache.Add(t.Torrent.InfoHash(), true)
 				if len(tm.seedingTorrents) > params.LimitSeeding {
 					tm.dropSeeding(tm.slot)
 				} else if len(tm.seedingTorrents) > tm.maxSeedTask {
@@ -506,8 +512,10 @@ func (tm *TorrentManager) init() {
 	//if tm.cache {
 	log.Debug("Chain files init", "files", len(GoodFiles))
 
-	for k, _ := range GoodFiles {
-		tm.Search(context.Background(), k, 0, nil)
+	for k, ok := range GoodFiles {
+		if tm.mode != LAZY || ok {
+			tm.Search(context.Background(), k, 0, nil)
+		}
 	}
 
 	log.Debug("Chain files OK !!!")
@@ -551,7 +559,14 @@ func (tm *TorrentManager) mainLoop() {
 				if bytes > 0 {
 					tm.updateInfoHash(t, bytes)
 				}
+
+				//if t.currentConns <= 1 {
+				//	t.currentConns = tm.maxEstablishedConns
+				//	t.Torrent.SetMaxEstablishedConns(tm.maxEstablishedConns)
+				//	log.Warn("Active torrent", "ih", meta.InfoHash, "bytes", bytes)
+				//}
 			}
+			//time.Sleep(time.Second)
 		case <-tm.closeAll:
 			return
 		}
@@ -591,7 +606,7 @@ func (tm *TorrentManager) pendingLoop() {
 							tm.activeChan <- t
 						}
 					}
-				} else if tm.boost && (t.loop > torrentWaitingTime/queryTimeInterval || (t.start == 0 && t.bytesRequested > 0)) {
+					/*} else if tm.boost && (t.loop > torrentWaitingTime/queryTimeInterval || (t.start == 0 && t.bytesRequested > 0)) {
 					if !t.isBoosting {
 						t.loop = 0
 						t.isBoosting = true
@@ -614,7 +629,7 @@ func (tm *TorrentManager) pendingLoop() {
 							}
 							t.BoostOff()
 						}
-					}
+					}*/
 				} else {
 					if _, ok := GoodFiles[t.InfoHash()]; t.start == 0 && (ok || t.bytesRequested > 0 || tm.mode == FULL || t.loop > 600) {
 						if ok {
@@ -650,6 +665,10 @@ func (tm *TorrentManager) activeLoop() {
 			for ih, t := range tm.activeTorrents {
 				//BytesRequested := int64(0)
 				if _, ok := GoodFiles[t.InfoHash()]; ok {
+					tm.lock.Lock()
+					t.bytesRequested = t.Length()
+					t.bytesLimitation = tm.getLimitation(t.bytesRequested)
+					tm.lock.Unlock()
 					t.fast = true
 				} else {
 					if tm.mode == FULL {
@@ -815,12 +834,23 @@ func (tm *TorrentManager) dropSeeding(slot int) error {
 				continue
 			}
 			if tm.hotCache.Contains(ih) {
-				log.Warn("Encounter active torrent", "ih", ih, "index", i, "group", s, "slot", slot, "len", len(tm.seedingTorrents), "max", tm.maxSeedTask, "peers", t.currentConns, "cited", t.cited)
+				log.Debug("Encounter active torrent", "ih", ih, "index", i, "group", s, "slot", slot, "len", len(tm.seedingTorrents), "max", tm.maxSeedTask, "peers", t.currentConns, "cited", t.cited)
 				continue
 			}
-			t.currentConns = 1
+
+			if tm.mode == LAZY {
+				//		tm.lock.Lock()
+				t.currentConns = 0
+				//		delete(tm.seedingTorrents, ih)
+				//		delete(tm.torrents, ih)
+				//		tm.lock.Unlock()
+				//	t.Torrent.Drop()
+				log.Debug("Lazy mode dropped", "ih", ih, "seeding", len(tm.seedingTorrents), "torrents", len(tm.torrents), "max", tm.maxSeedTask, "peers", t.currentConns, "cited", t.cited)
+			} else {
+				t.currentConns = 1
+			}
 			t.Torrent.SetMaxEstablishedConns(t.currentConns)
-			log.Warn("Drop seeding invoke", "ih", ih, "index", i, "group", s, "slot", slot, "len", len(tm.seedingTorrents), "max", tm.maxSeedTask, "peers", t.currentConns, "cited", t.cited)
+			log.Debug("Drop seeding invoke", "ih", ih, "index", i, "group", s, "slot", slot, "len", len(tm.seedingTorrents), "max", tm.maxSeedTask, "peers", t.currentConns, "cited", t.cited)
 		}
 		i++
 	}
@@ -837,58 +867,69 @@ func (tm *TorrentManager) graceSeeding(slot int) error {
 				continue
 			}
 			if tm.hotCache.Contains(ih) {
-				log.Warn("Encounter active torrent", "ih", ih, "index", i, "group", s, "slot", slot, "len", len(tm.seedingTorrents), "max", tm.maxSeedTask, "peers", t.currentConns, "cited", t.cited)
+				log.Debug("Encounter active torrent", "ih", ih, "index", i, "group", s, "slot", slot, "len", len(tm.seedingTorrents), "max", tm.maxSeedTask, "peers", t.currentConns, "cited", t.cited)
 				continue
 			}
-			t.currentConns = t.minEstablishedConns
+			if tm.mode == LAZY {
+				t.currentConns = 1
+			} else {
+				t.currentConns = t.minEstablishedConns
+			}
 			t.Torrent.SetMaxEstablishedConns(t.currentConns)
-			log.Warn("Grace seeding invoke", "ih", ih, "index", i, "group", s, "slot", slot, "len", len(tm.seedingTorrents), "max", tm.maxSeedTask, "peers", t.currentConns, "cited", t.cited)
+			log.Debug("Grace seeding invoke", "ih", ih, "index", i, "group", s, "slot", slot, "len", len(tm.seedingTorrents), "max", tm.maxSeedTask, "peers", t.currentConns, "cited", t.cited)
 		}
 		i++
 	}
 	return nil
 }
 
-func (tm *TorrentManager) available(infohash string, rawSize uint64) (bool, error) {
+func (tm *TorrentManager) available(infohash string, rawSize uint64) (bool, uint64, error) {
 	availableMeter.Mark(1)
 	if rawSize <= 0 {
-		return false, errors.New("raw size is zero or negative")
+		return false, 0, errors.New("raw size is zero or negative")
 	}
 
 	if !common.IsHexAddress(infohash) {
-		return false, errors.New("Invalid infohash format")
+		return false, 0, errors.New("Invalid infohash format")
 	}
 
 	ih := metainfo.NewHashFromHex(strings.TrimPrefix(strings.ToLower(infohash), common.Prefix))
-	if torrent := tm.getTorrent(ih); torrent == nil {
-		return false, ErrInactiveTorrent
+	if t := tm.getTorrent(ih); t == nil {
+		return false, 0, ErrInactiveTorrent
 	} else {
-		if !torrent.Ready() {
+		if !t.Ready() {
 			//if torrent.ch != nil {
 			//	<-torrent.ch
 			//	if torrent.Ready() {
 			//		return torrent.BytesCompleted() <= int64(rawSize), nil
 			//	}
 			//}
-			return false, ErrUnfinished
+			return false, uint64(t.BytesCompleted()), ErrUnfinished
 		}
-		return torrent.BytesCompleted() <= int64(rawSize), nil
+
+		ok := t.BytesCompleted() <= int64(rawSize)
+		//if t.currentConns <= 1 && ok {
+		//	t.currentConns = tm.maxEstablishedConns
+		//	t.Torrent.SetMaxEstablishedConns(tm.maxEstablishedConns)
+		//}
+
+		return ok, uint64(t.BytesCompleted()), nil
 	}
 }
 
-func (tm *TorrentManager) getFile(infohash, subpath string) ([]byte, error) {
+func (tm *TorrentManager) getFile(infohash, subpath string) ([]byte, uint64, error) {
 	getfileMeter.Mark(1)
 	if tm.metrics {
 		defer func(start time.Time) { tm.Updates += time.Since(start) }(time.Now())
 	}
 
 	if !common.IsHexAddress(infohash) {
-		return nil, errors.New("Invalid infohash format")
+		return nil, 0, errors.New("Invalid infohash format")
 	}
 	ih := metainfo.NewHashFromHex(strings.TrimPrefix(strings.ToLower(infohash), common.Prefix))
 
 	if torrent := tm.getTorrent(ih); torrent == nil {
-		return nil, ErrInactiveTorrent
+		return nil, 0, ErrInactiveTorrent
 	} else {
 
 		subpath = strings.TrimPrefix(subpath, "/")
@@ -896,14 +937,14 @@ func (tm *TorrentManager) getFile(infohash, subpath string) ([]byte, error) {
 
 		if !torrent.Ready() {
 			log.Error("Read unavailable file", "hash", infohash, "subpath", subpath)
-			return nil, errors.New("download not completed")
+			return nil, uint64(torrent.BytesCompleted()), ErrUnfinished
 		}
 
 		tm.hotCache.Add(ih, true)
 		if torrent.currentConns < tm.maxEstablishedConns {
 			torrent.currentConns = tm.maxEstablishedConns
 			torrent.SetMaxEstablishedConns(torrent.currentConns)
-			log.Info("Torrent active", "ih", ih, "peers", torrent.currentConns)
+			log.Debug("Torrent active", "ih", ih, "peers", torrent.currentConns)
 		}
 
 		var key = filepath.Join(infohash, subpath)
@@ -912,12 +953,12 @@ func (tm *TorrentManager) getFile(infohash, subpath string) ([]byte, error) {
 				memcacheHitMeter.Mark(1)
 				memcacheReadMeter.Mark(int64(len(cache)))
 				if c, err := tm.unzip(cache); err != nil {
-					return nil, err
+					return nil, 0, err
 				} else {
 					if tm.compress {
 						log.Info("File cache", "hash", infohash, "path", subpath, "size", tm.fileCache.Len(), "compress", len(cache), "origin", len(c), "compress", tm.compress)
 					}
-					return c, nil
+					return c, uint64(torrent.BytesCompleted()), nil
 				}
 			}
 		}
@@ -933,7 +974,7 @@ func (tm *TorrentManager) getFile(infohash, subpath string) ([]byte, error) {
 				log.Debug("File location info", "ih", infohash, "path", file.Path(), "key", key)
 				if int64(len(data)) != file.Length() {
 					log.Error("Read file not completed", "hash", infohash, "len", len(data), "total", file.Path())
-					return nil, errors.New("not a complete file")
+					return nil, 0, errors.New("not a complete file")
 				} else {
 					log.Debug("Read data success", "hash", infohash, "size", len(data), "path", file.Path())
 					if c, err := tm.zip(data); err != nil {
@@ -950,7 +991,7 @@ func (tm *TorrentManager) getFile(infohash, subpath string) ([]byte, error) {
 			}
 		}
 
-		return data, err
+		return data, uint64(torrent.BytesCompleted()), err
 	}
 }
 

--- a/handler.go
+++ b/handler.go
@@ -667,8 +667,8 @@ func (tm *TorrentManager) activeLoop() {
 					tm.lock.Lock()
 					t.bytesRequested = t.Length()
 					t.bytesLimitation = tm.getLimitation(t.bytesRequested)
-					t.fast = true
 					tm.lock.Unlock()
+					t.fast = true
 				} else {
 					if tm.mode == FULL {
 						if t.bytesRequested >= t.Length() {
@@ -678,8 +678,8 @@ func (tm *TorrentManager) activeLoop() {
 								tm.lock.Lock()
 								t.bytesRequested = int64(math.Min(float64(t.Length()), float64(t.bytesRequested+block)))
 								t.bytesLimitation = tm.getLimitation(t.bytesRequested)
-								t.fast = false
 								tm.lock.Unlock()
+								t.fast = false
 							}
 						}
 					} else {
@@ -687,9 +687,7 @@ func (tm *TorrentManager) activeLoop() {
 							t.fast = true
 						} else {
 							if t.bytesRequested <= t.BytesCompleted()+block/2 {
-								tm.lock.Lock()
 								t.fast = false
-								tm.lock.Unlock()
 							}
 						}
 					}

--- a/handler.go
+++ b/handler.go
@@ -558,13 +558,12 @@ func (tm *TorrentManager) mainLoop() {
 			} else {
 				if bytes > 0 {
 					tm.updateInfoHash(t, bytes)
+					if t.currentConns <= 1 {
+						t.currentConns = tm.maxEstablishedConns
+						t.Torrent.SetMaxEstablishedConns(tm.maxEstablishedConns)
+						log.Warn("Active torrent", "ih", meta.InfoHash, "bytes", bytes)
+					}
 				}
-
-				//if t.currentConns <= 1 {
-				//	t.currentConns = tm.maxEstablishedConns
-				//	t.Torrent.SetMaxEstablishedConns(tm.maxEstablishedConns)
-				//	log.Warn("Active torrent", "ih", meta.InfoHash, "bytes", bytes)
-				//}
 			}
 			//time.Sleep(time.Second)
 		case <-tm.closeAll:

--- a/handler_test.go
+++ b/handler_test.go
@@ -34,9 +34,9 @@ func TestGetFile(t *testing.T) {
 	tm.Search(context.Background(), ih, 0, nil)
 	defer tm.Close()
 	time.Sleep(5 * time.Second)
-	a, _ := tm.available(ih, 100000000)
+	a, _, _ := tm.available(ih, 100000000)
 	fmt.Println("available", a)
-	file, _ := tm.getFile(ih, "data")
+	file, _, _ := tm.getFile(ih, "data")
 	if file == nil {
 		log.Fatal("failed to get file")
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -34,7 +34,7 @@ func TestGetFile(t *testing.T) {
 	tm.Search(context.Background(), ih, 0, nil)
 	defer tm.Close()
 	time.Sleep(5 * time.Second)
-	a, _, _ := tm.available(ih, 100000000)
+	a, _, _, _ := tm.available(ih, 100000000)
 	fmt.Println("available", a)
 	file, _, _ := tm.getFile(ih, "data")
 	if file == nil {

--- a/handler_test.go
+++ b/handler_test.go
@@ -31,7 +31,7 @@ func TestGetFile(t *testing.T) {
 	fmt.Println(DefaultConfig)
 	tm, _ := NewTorrentManager(&DefaultConfig, 1, false, false)
 	tm.Start()
-	tm.Search(context.Background(), ih, 100000000, nil)
+	tm.Search(context.Background(), ih, 0, nil)
 	defer tm.Close()
 	time.Sleep(5 * time.Second)
 	a, _ := tm.available(ih, 100000000)

--- a/params/config.go
+++ b/params/config.go
@@ -24,5 +24,5 @@ const (
 	//Scope     = 4
 	//TIER         = 3
 	//LEAFS        = 32768
-	LimitSeeding = 2
+	LimitSeeding = 2048
 )

--- a/params/config.go
+++ b/params/config.go
@@ -23,6 +23,6 @@ const (
 	Delay     = 6
 	//Scope     = 4
 	//TIER         = 3
-	LEAFS        = 32768
-	LimitSeeding = 2048
+	//LEAFS        = 32768
+	LimitSeeding = 2
 )

--- a/peer.go
+++ b/peer.go
@@ -154,7 +154,7 @@ func (peer *Peer) broadcast() error {
 					Size: v.(uint64),
 				}
 				//log.Debug("Broadcast", "ih", k.(string), "size", v.(uint64))
-				if err := p2p.Send(peer.ws, messagesCode, &query); err != nil {
+				if err := p2p.Send(peer.ws, queryCode, &query); err != nil {
 					return err
 				}
 				peer.mark(k.(string))

--- a/peer.go
+++ b/peer.go
@@ -138,7 +138,13 @@ func (peer *Peer) handshake() error {
 	go func() {
 		defer peer.wg.Done()
 		log.Debug("Nas send items", "status", statusCode, "version", ProtocolVersion)
-		errc <- p2p.SendItems(peer.ws, statusCode, ProtocolVersion, &PeerInfo{Listen: uint64(peer.host.LocalPort()), Root: peer.host.chain().Root(), Files: uint64(peer.host.Congress()), Leafs: uint64(len(peer.host.chain().Blocks()))})
+		info := PeerInfo{
+			Listen: uint64(peer.host.LocalPort()),
+			Root:   peer.host.chain().Root(),
+			Files:  uint64(peer.host.Congress()),
+			Leafs:  uint64(len(peer.host.chain().Blocks())),
+		}
+		errc <- p2p.SendItems(peer.ws, statusCode, ProtocolVersion, &info)
 		log.Debug("Nas send items OK", "status", statusCode, "version", ProtocolVersion, "len", len(errc))
 	}()
 	// Fetch the remote status packet and verify protocol match

--- a/peer.go
+++ b/peer.go
@@ -22,7 +22,7 @@ import (
 	"github.com/CortexFoundation/CortexTheseus/log"
 	"github.com/CortexFoundation/CortexTheseus/p2p"
 	"github.com/CortexFoundation/CortexTheseus/rlp"
-	lru "github.com/hashicorp/golang-lru"
+	mapset "github.com/ucwong/golang-set"
 	"sync"
 	"time"
 )
@@ -35,7 +35,7 @@ type Peer struct {
 
 	trusted bool
 
-	known *lru.Cache // Messages already known by the peer to avoid wasting bandwidth
+	known mapset.Set
 	quit  chan struct{}
 
 	wg sync.WaitGroup
@@ -58,10 +58,10 @@ func newPeer(id string, host *TorrentFS, remote *p2p.Peer, rw p2p.MsgReadWriter)
 		host:    host,
 		peer:    remote,
 		ws:      rw,
+		known:   mapset.NewSet(),
 		trusted: false,
 		quit:    make(chan struct{}),
 	}
-	p.known, _ = lru.New(25)
 	return &p
 }
 
@@ -75,16 +75,40 @@ func (peer *Peer) start() error {
 	return nil
 }
 
+func (peer *Peer) expire() {
+	unmark := make(map[string]struct{})
+	peer.known.Each(func(k interface{}) bool {
+		if _, ok := peer.host.nasCache.Get(k.(string)); !ok {
+			unmark[k.(string)] = struct{}{}
+		}
+		return true
+	})
+	// Dump all known but no longer cached
+	for hash := range unmark {
+		peer.known.Remove(hash)
+		log.Warn("Peer msg expire", "ih", hash, "know", peer.known.Cardinality(), "cache", peer.host.nasCache.Len())
+	}
+}
+
 func (peer *Peer) update() {
 	defer peer.wg.Done()
 	stateTicker := time.NewTicker(peerStateCycle)
 	defer stateTicker.Stop()
 
+	transmit := time.NewTicker(transmissionCycle)
+	defer transmit.Stop()
+
+	expire := time.NewTicker(expirationCycle)
+	defer expire.Stop()
+
 	// Loop and transmit until termination is requested
 	for {
 		select {
-		case query := <-peer.host.queryChan:
-			if err := peer.broadcast(query); err != nil {
+		case <-expire.C:
+			peer.expire()
+		//case query := <-peer.host.queryChan:
+		case <-transmit.C:
+			if err := peer.broadcast(); err != nil {
 				log.Trace("broadcast failed", "reason", err, "peer", peer.ID())
 				return
 			}
@@ -118,16 +142,30 @@ type Query struct {
 	Size uint64 `json:"size"`
 }
 
-func (peer *Peer) broadcast(query Query) error {
-	if _, ok := peer.known.Get(query.Hash); ok {
-		return nil
-	}
-	//filter
-	if err := p2p.Send(peer.ws, messagesCode, &query); err != nil {
-		return err
+func (peer *Peer) mark(hash string) {
+	peer.known.Add(hash)
+}
+
+func (peer *Peer) marked(hash string) bool {
+	return peer.known.Contains(hash)
+}
+
+func (peer *Peer) broadcast() error {
+	for _, k := range peer.host.nasCache.Keys() {
+		if v, ok := peer.host.nasCache.Get(k.(string)); ok {
+			if !peer.marked(k.(string)) {
+				query := Query{
+					Hash: k.(string),
+					Size: v.(uint64),
+				}
+				if err := p2p.Send(peer.ws, messagesCode, &query); err != nil {
+					return err
+				}
+				peer.mark(k.(string))
+			}
+		}
 	}
 
-	peer.known.Add(query.Hash, query.Size)
 	return nil
 }
 

--- a/peer.go
+++ b/peer.go
@@ -78,7 +78,7 @@ func (peer *Peer) start() error {
 func (peer *Peer) expire() {
 	unmark := make(map[string]struct{})
 	peer.known.Each(func(k interface{}) bool {
-		if _, ok := peer.host.nasCache.Get(k.(string)); !ok {
+		if _, ok := peer.host.nasCache.Peek(k.(string)); !ok {
 			unmark[k.(string)] = struct{}{}
 		}
 		return true
@@ -152,12 +152,13 @@ func (peer *Peer) marked(hash string) bool {
 
 func (peer *Peer) broadcast() error {
 	for _, k := range peer.host.nasCache.Keys() {
-		if v, ok := peer.host.nasCache.Get(k.(string)); ok {
+		if v, ok := peer.host.nasCache.Peek(k.(string)); ok {
 			if !peer.marked(k.(string)) {
 				query := Query{
 					Hash: k.(string),
 					Size: v.(uint64),
 				}
+				log.Error("Broadcast", "ih", k.(string), "size", v.(uint64))
 				if err := p2p.Send(peer.ws, messagesCode, &query); err != nil {
 					return err
 				}

--- a/peer.go
+++ b/peer.go
@@ -28,20 +28,15 @@ import (
 )
 
 type Peer struct {
-	id   string
-	host *TorrentFS
-	peer *p2p.Peer
-	ws   p2p.MsgReadWriter
-
-	trusted bool
-
-	known mapset.Set
-	quit  chan struct{}
-
-	wg sync.WaitGroup
-
-	version uint64
-
+	id       string
+	host     *TorrentFS
+	peer     *p2p.Peer
+	ws       p2p.MsgReadWriter
+	trusted  bool
+	known    mapset.Set
+	quit     chan struct{}
+	wg       sync.WaitGroup
+	version  uint64
 	peerInfo *PeerInfo
 }
 
@@ -86,7 +81,7 @@ func (peer *Peer) expire() {
 	// Dump all known but no longer cached
 	for hash := range unmark {
 		peer.known.Remove(hash)
-		log.Warn("Peer msg expire", "ih", hash, "know", peer.known.Cardinality(), "cache", peer.host.nasCache.Len())
+		//log.Warn("Peer msg expire", "ih", hash, "know", peer.known.Cardinality(), "cache", peer.host.nasCache.Len())
 	}
 }
 
@@ -158,7 +153,7 @@ func (peer *Peer) broadcast() error {
 					Hash: k.(string),
 					Size: v.(uint64),
 				}
-				log.Error("Broadcast", "ih", k.(string), "size", v.(uint64))
+				//log.Debug("Broadcast", "ih", k.(string), "size", v.(uint64))
 				if err := p2p.Send(peer.ws, messagesCode, &query); err != nil {
 					return err
 				}

--- a/sync.go
+++ b/sync.go
@@ -466,25 +466,25 @@ func (m *Monitor) exit() {
 
 func (m *Monitor) stop() {
 	//m.closeOnce.Do(func() {
-		if atomic.LoadInt32(&(m.terminated)) == 1 {
-			return
-		}
-		atomic.StoreInt32(&(m.terminated), 1)
+	if atomic.LoadInt32(&(m.terminated)) == 1 {
+		return
+	}
+	atomic.StoreInt32(&(m.terminated), 1)
 
-		m.exit()
-		log.Info("Monitor is waiting to be closed")
-		m.blockCache.Purge()
-		m.sizeCache.Purge()
+	m.exit()
+	log.Info("Monitor is waiting to be closed")
+	m.blockCache.Purge()
+	m.sizeCache.Purge()
 
-		log.Info("Fs client listener synchronizing closing")
-		if err := m.dl.Close(); err != nil {
-			log.Error("Monitor Fs Manager closed", "error", err)
-		}
+	log.Info("Fs client listener synchronizing closing")
+	if err := m.dl.Close(); err != nil {
+		log.Error("Monitor Fs Manager closed", "error", err)
+	}
 
-		if err := m.fs.Close(); err != nil {
-			log.Error("Monitor File Storage closed", "error", err)
-		}
-		log.Info("Fs listener synchronizing closed")
+	if err := m.fs.Close(); err != nil {
+		log.Error("Monitor File Storage closed", "error", err)
+	}
+	log.Info("Fs listener synchronizing closed")
 	//})
 }
 

--- a/sync.go
+++ b/sync.go
@@ -453,17 +453,19 @@ func (m *Monitor) parseBlockTorrentInfo(b *types.Block) (bool, error) {
 }
 
 func (m *Monitor) exit() {
-	if m.exitCh != nil {
-		close(m.exitCh)
-		m.wg.Wait()
-		m.exitCh = nil
-	} else {
-		log.Warn("Listener has already been stopped")
-	}
+	m.closeOnce.Do(func() {
+		if m.exitCh != nil {
+			close(m.exitCh)
+			m.wg.Wait()
+			m.exitCh = nil
+		} else {
+			log.Warn("Listener has already been stopped")
+		}
+	})
 }
 
 func (m *Monitor) stop() {
-	m.closeOnce.Do(func() {
+	//m.closeOnce.Do(func() {
 		if atomic.LoadInt32(&(m.terminated)) == 1 {
 			return
 		}
@@ -483,7 +485,7 @@ func (m *Monitor) stop() {
 			log.Error("Monitor File Storage closed", "error", err)
 		}
 		log.Info("Fs listener synchronizing closed")
-	})
+	//})
 }
 
 // Start ... start ListenOn on the rpc port of a blockchain full node

--- a/torrent.go
+++ b/torrent.go
@@ -173,7 +173,7 @@ func (t *Torrent) Seed() bool {
 	if t.Torrent.Seeding() {
 		t.status = torrentSeeding
 		elapsed := time.Duration(mclock.Now()) - time.Duration(t.start)
-		log.Info("Imported new segment", "hash", common.HexToHash(t.InfoHash()), "size", common.StorageSize(t.BytesCompleted()), "files", len(t.Files()), "pieces", t.Torrent.NumPieces(), "seg", len(t.Torrent.PieceStateRuns()), "cited", t.cited, "peers", t.currentConns, "status", t.status, "elapsed", common.PrettyDuration(elapsed))
+		log.Info("Imported new segment", "ih", t.InfoHash(), "size", common.StorageSize(t.BytesCompleted()), "files", len(t.Files()), "pieces", t.Torrent.NumPieces(), "seg", len(t.Torrent.PieceStateRuns()), "cited", t.cited, "peers", t.currentConns, "status", t.status, "elapsed", common.PrettyDuration(elapsed))
 		return true
 	}
 


### PR DESCRIPTION
Experiment for nas 2.0 under new downloading mode

1. Nas is a protocol for cortex torrent seeding information transmit.
2. It is an active request for seeding instead of waiting for sources
3. Nas 2.0 can wake up sleeping file in cortex, anytime you want it.
4. Nas 2.0 is only for lazy node for now

![image](https://user-images.githubusercontent.com/22344498/89162741-119d5600-d5a7-11ea-903a-d41dc608ad2c.png)

From above you can see a file is failing to be found ```(60 seconds limit before call nas2.0)``` until nas2.0 invoked, then find the file immediately